### PR TITLE
Add test reporting to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,5 +37,5 @@ jobs:
       with:
         name: Go Tests
         path: test-report.json
-        reporter: go-test-json
+        reporter: golang-json
         fail-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
     - uses: actions/checkout@v4
 
@@ -25,4 +28,14 @@ jobs:
       run: go build -v ./...
 
     - name: Test
-      run: go test -v ./...
+      run: go test -json ./... > test-report.json
+      continue-on-error: true
+
+    - name: Test Report
+      uses: dorny/test-reporter@v2
+      if: always()
+      with:
+        name: Go Tests
+        path: test-report.json
+        reporter: go-test-json
+        fail-on-error: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 *A terminal dashboard for Jenkins*
 
+[![Go Tests](https://github.com/gorbach/jdash/actions/workflows/build.yml/badge.svg)](https://github.com/gorbach/jdash/actions/workflows/build.yml)
 ![Status: Alpha](https://img.shields.io/badge/status-alpha-orange)
 ![Go 1.25+](https://img.shields.io/badge/go-1.21+-blue)
 


### PR DESCRIPTION
## Summary
Adds visual test reporting to the GitHub Actions workflow using `dorny/test-reporter@v2`.

## Changes
- Added `dorny/test-reporter@v2` for generating test summaries
- Configured required permissions (`checks: write`)
- Modified test step to output JSON format
- Tests now generate detailed reports visible in the Checks tab

## Benefits
- Visual test result summaries on every push/PR
- Easy-to-read pass/fail status for individual tests
- Test execution times and failure details
- Better visibility into test failures without reading raw logs

## Testing
Once this PR is created, the workflow will run and demonstrate the test reporter in action.